### PR TITLE
Update btc-stats.js

### DIFF
--- a/lib/btc-stats.js
+++ b/lib/btc-stats.js
@@ -20,8 +20,12 @@ BtcStats.prototype.exchanges = function(excs) {
 function tickersResp(callback) {
 	async.map(Object.keys(this._exchanges), function(item, cb){
 		xchange[item].ticker(function(error, resp){
-			resp.ticker = item;
-			return cb(error, resp);
+			if (error || !resp) {
+				return cb(error, null);
+			} else {
+				resp.ticker = item;
+				return cb(error, resp);
+			}
 		});
 	}, callback);
 }


### PR DESCRIPTION
An error occur if returned resp object is null.

```
(err) TypeError: Cannot set property 'ticker' of undefined
(err):     at /var/www/exchange-ci/node_modules/btc-stats/lib/btc-stats.js:23:16
```
